### PR TITLE
Added build step for updating to latest CocoaPods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The app demonstrates how to use Core Data, unit tests, ReactiveCocoa, and Model-
 Building 
 ----------------
 
+If necessary, [update](http://guides.cocoapods.org/using/getting-started.html#updating-cocoapods) to the latest version of CocoaPods.
+
 Clone the repository, then run `pod install`, opening the generated Xcode workspace. 
 
 Testing


### PR DESCRIPTION
I was getting an error similar to this one after building C-41: https://github.com/ReactiveCocoa/ReactiveCocoa/issues/866. The issue was that I was running an older version of CocoaPods. I upgraded to the latest CocoaPods and the build issue went away after retrying.
