### PR TITLE
fix memory leaks

### DIFF
--- a/C-41/ASHTimerViewController.m
+++ b/C-41/ASHTimerViewController.m
@@ -72,6 +72,7 @@
 }
 
 -(void)cancel {
+    [self pause];
     [self dismiss];
 }
 


### PR DESCRIPTION
don’t pause timer, then pop from timer controller when clicked `Cancel`
button, the timer will go on.